### PR TITLE
Integrate with the EVENT Google Sheet to store our events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ token.txt
 credentials.json
 secrets.cfg
 generated.cfg
+venv/*

--- a/bin/print_events.py
+++ b/bin/print_events.py
@@ -34,6 +34,9 @@ async def main():
     logging.getLogger().setLevel(logging.DEBUG)
 
     handler = get_default_event_sheet_handler()
+    new_players = await handler.resync_player_list()
+    if new_players:
+        print("New players added from the roster: ", new_players)
     attendances = await handler.get_all_attendances()
     data = []
     for attendance in attendances:

--- a/bin/print_events.py
+++ b/bin/print_events.py
@@ -21,7 +21,7 @@ import logging
 
 from tabulate import tabulate
 
-from event.sheet_integration import get_default_sheet_handler
+from event.sheet_integration import get_default_event_sheet_handler
 
 
 async def main():
@@ -33,13 +33,18 @@ async def main():
     """
     logging.getLogger().setLevel(logging.DEBUG)
 
-    handler = get_default_sheet_handler()
-    events = await handler.get_events()
+    handler = get_default_event_sheet_handler()
+    attendances = await handler.get_all_attendances()
     data = []
-    for event in events:
-        data.append([event.date.isoformat(), event.title, event.description])
+    for attendance in attendances:
+        data.append([
+            attendance.event.date.isoformat(),
+            attendance.event.title,
+            attendance.event.description,
+            attendance.availabilities,
+        ])
 
-    print(tabulate(data, headers=["Date", "Title", "Description"]))
+    print(tabulate(data, headers=["Date", "Title", "Description", "Availabilities"]))
 
 
 if __name__ == "__main__":

--- a/bin/print_events.py
+++ b/bin/print_events.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+__LICENSE__ = """
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+import logging
+
+from tabulate import tabulate
+
+from event.sheet_integration import get_default_sheet_handler
+
+
+async def main():
+    """Pulls the list of players present in the spreadsheet.
+
+    Fairly simple script retrieving all the players from the configured
+    spreadsheet and displaying them in a table. Useful to manually test
+    integration with the spreadsheet.
+    """
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    handler = get_default_sheet_handler()
+    events = await handler.get_events()
+    data = []
+    for event in events:
+        data.append([event.date.isoformat(), event.title, event.description])
+
+    print(tabulate(data, headers=["Date", "Title", "Description"]))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bin/print_roster.py
+++ b/bin/print_roster.py
@@ -20,7 +20,7 @@ import asyncio
 
 from tabulate import tabulate
 
-from roster.sheet_integration import get_default_sheet_handler
+from roster.sheet_integration import get_default_roster_sheet_handler
 
 
 async def main():
@@ -30,7 +30,7 @@ async def main():
     spreadsheet and displaying them in a table. Useful to manually test
     integration with the spreadsheet.
     """
-    handler = get_default_sheet_handler()
+    handler = get_default_roster_sheet_handler()
     players = await handler.get_players()
     data = []
     for player in players:

--- a/config/google.py
+++ b/config/google.py
@@ -64,6 +64,23 @@ if _base64_token:
                 'is invalid and cannot be used.')
         token = None
 
+
+# The google sheets service handler.
+_service = None
+
+
+def get_sheets_handler():
+    """Returns a unique service handler to Google services."""
+    global _service, token
+    if _service is not None:
+        return _service
+
+    if token is None:
+        raise ConfigurationError(
+            'Attempted to get a Google Sheets API handler without the '
+            'appropriates API tokens. Use the script bin/generate_tokens.py '
+            'to create the access tokens.')
+
     # Sometimes tokens needs to be renewed. This is generally a one time,
     # fairly trivial operation and a one time. Make it happen at the
     # initialization.
@@ -82,20 +99,5 @@ if _base64_token:
                 'is invalid and cannot be refreshed; Google integration is '
                 'likely to have troubles.')
 
-# The google sheets service handler.
-_service = None
-
-
-def get_sheets_handler():
-    """Returns a unique service handler to Google services."""
-    global _service
-    if _service is not None:
-        return _service
-
-    if token is None:
-        raise ConfigurationError(
-            'Attempted to get a Google Sheets API handler without the '
-            'appropriates API tokens. Use the script bin/generate_tokens.py '
-            'to create the access tokens.')
     _service = build('sheets', 'v4', credentials=token)
     return _service

--- a/event/attendance.py
+++ b/event/attendance.py
@@ -1,0 +1,45 @@
+"""Attendance records for a given event."""
+
+from __future__ import annotations
+
+__LICENSE__ = """
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from enum import Enum
+from typing import Dict
+
+from event.event import Event
+from roster.model import Player
+
+class Availability(Enum):
+    """Availability of a player for a given event."""
+    signed = "SIGNED"
+    unavailable = "UNAVAILABLE"
+    unknown = "UNKNOWN"
+
+    def __repr__(self):
+        return '<Availability {}>'.format(self.value)
+
+
+class Attendance:
+    """Player attendance to an event."""
+    event: Event
+    availabilities: Dict[Player, Availability]
+
+    def __init__(self, event: Event, availabilities: Dict[Player, Availability] = None):
+        self.event = event
+        self.availabilities = availabilities or {}
+

--- a/event/event.py
+++ b/event/event.py
@@ -18,6 +18,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import dateutil.parser
+
 from datetime import datetime, timedelta
 from enum import Enum
 from pytz import timezone
@@ -41,6 +43,12 @@ class StandardTimezone(Enum):
             return cls[string]
         except KeyError:
             raise ValueError("Timezone %s is not supported." % string)
+
+
+def date_from_string(date_str: str, time_str: str, tz = StandardTimezone.utc):
+    """Creates an aware datetime object from a date and time string."""
+    unaware_date = dateutil.parser.parse(f'{date_str} {time_str}')
+    return tz.value.localize(unaware_date)
 
 
 class Event(Serializable):

--- a/event/sheet_integration.py
+++ b/event/sheet_integration.py
@@ -36,7 +36,11 @@ def column_offset(column: str) -> int:
     """Returns the column offset from the column A of the spreadsheet."""
     index = 0
     for i, c in enumerate(reversed(column)):
-        index += 26 ** i * string.ascii_uppercase.index(column.upper())
+        letter_offset = string.ascii_uppercase.index(c.upper())
+        if i > 0:
+            index += 26 ** i * (letter_offset + 1)
+        else:
+            index += string.ascii_uppercase.index(c.upper())
     return index
 
 

--- a/event/sheet_integration.py
+++ b/event/sheet_integration.py
@@ -25,7 +25,7 @@ import logging
 
 from typing import List, Dict, Any, Union
 
-from google_integration.handler import get_handler
+from config.google import get_sheets_handler
 from event.event import Event, StandardTimezone, date_from_string
 from event.attendance import Attendance, Availability
 from roster.sheet_integration import RosterSpreadsheet, get_default_roster_sheet_handler
@@ -187,7 +187,7 @@ THE_UNIQUE_ROSTER_SHEET = "EVENTS"
 
 def get_default_event_sheet_handler() -> EventSpreadsheet:
     """Returns the default spreadsheet to use in this context."""
-    return EventSpreadsheet(get_handler().spreadsheets(),
+    return EventSpreadsheet(get_sheets_handler().spreadsheets(),
                             get_default_roster_sheet_handler(),
                             THE_UNIQUE_SPREADSHEET_ID,
                             THE_UNIQUE_ROSTER_SHEET)

--- a/event/sheet_integration.py
+++ b/event/sheet_integration.py
@@ -1,0 +1,151 @@
+"""Integration with Google Sheets, storing the events."""
+
+from __future__ import annotations
+
+__LICENSE__ = """
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+import threading
+import string
+import logging
+
+from enum import Enum
+from typing import List, Dict, Any
+
+from google_integration.handler import get_handler
+from event.event import Event, StandardTimezone, date_from_string
+
+
+class Availability(Enum):
+    """Availability of a player for a given event."""
+    signed = "SIGNED"
+    unavailable = "UNAVAILABLE"
+    unknown = "UNKNOWN"
+
+
+def column_offset(column: str) -> int:
+    """Returns the column offset from the column A of the spreadsheet."""
+    index = 0
+    for i, c in enumerate(reversed(column)):
+        index += 26 ** i * string.ascii_uppercase.index(column.upper())
+    return index
+
+
+class EventSpreadsheet:
+    """Interface to the event spreadsheet.
+
+    :attr LINE_START_OFFSET: the exact line the content of the spreadsheet starts.
+    """
+
+    LINE_START_OFFSET = 8
+    COLUMN_END_METADATA = column_offset('D') + 1
+    COLUMN_START_PLAYER_STATUS = column_offset('H')
+    TIMEZONE = StandardTimezone.europe
+
+    def __init__(self, handler, spreadsheet_id, event_sheet_name):
+        self._spreadsheet_id = spreadsheet_id
+        self._events_a1_selector = (
+            f'{event_sheet_name}!A1:Z1000')
+        self._handler = handler
+        self._mutex = threading.Lock()
+
+        # Google Spreadsheets API have two different notations to access a
+        # specific sheet in a spreadsheet: using the A1 notation (for range
+        # of values selection), the name of the spreadsheet needs to be used,
+        # while some other endpoints may require the sheet ID (int32).
+        # So we need to resolve what's the sheet ID associated to the sheet
+        # name provided as argument.
+        spreadsheet_metadata = self._handler.get(
+            spreadsheetId=self._spreadsheet_id).execute()
+        self._EVENT_SHEET_ID = None
+        for sheet_metadata in spreadsheet_metadata.get('sheets', []):
+            if 'properties' not in sheet_metadata:
+                continue
+            properties = sheet_metadata['properties']
+            if properties.get('title') != event_sheet_name:
+                continue
+            self._EVENT_SHEET_ID = properties.get('sheetId')
+        if self._EVENT_SHEET_ID is None:
+            raise KeyError(
+                'Sheet name {} is missing in the spreadsheet {}'.format(
+                    event_sheet_name, self._spreadsheet_id))
+
+    async def get_events(self) -> List[Event]:
+        """Retrieves the list of events as configured in the spreadsheet."""
+        cursor = self._handler.values().get(
+            spreadsheetId=self._spreadsheet_id, range=self._events_a1_selector)
+
+        with self._mutex:
+            data = await self._execute(cursor)
+        assert data.get('values') is not None
+
+        # First row contains the list of players, which is then used to read there
+        # statuses.
+        headers = data['values'].pop(0)
+        player_uids = headers[self.COLUMN_START_PLAYER_STATUS:]
+
+        events = []
+        attendance_by_events = {}
+        for i, row in enumerate(data['values']):
+            if len(row) < self.COLUMN_START_PLAYER_STATUS:
+                logging.warning(
+                    'Skipping row %s with invalid content: expected %s '
+                    'values, got: %s',
+                    i, self.COLUMN_START_PLAYER_STATUS, row)
+                continue
+            metadata, player_status = row[:self.COLUMN_END_METADATA], row[self.COLUMN_START_PLAYER_STATUS:]
+            date_str, time_str, title, desc = metadata
+            date = date_from_string(date_str, time_str)
+
+            # TODO(funkysayu): support repetition of events.
+            event = Event(title, date, desc)
+            events.append(event)
+
+            # Get the status of each players for this event.
+            # TODO(funkysayu): use these values.
+            attendance = {}
+            for uid, status in zip(player_uids, player_status):
+                if not player_uids or not player_status:
+                    continue
+                try:
+                    attendance[uid] = Availability(status)
+                except ValueError:
+                    logging.error(
+                        "Invalid availability for player %s on event %s: got %s. "
+                        "Falling back to the default.",
+                        uid, event, status)
+                    attendance[uid] = Availability.unknown
+            attendance_by_events[event] = attendance
+            logging.info("Attendance for event %s: %s", event, attendance)
+        return events
+
+    async def _execute(self, cursor) -> Dict[str, Any]:
+        """Wraps cursor execution in an asyncio call."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, cursor.execute)
+
+
+# TODO(funkysayu): one day, make it non unique :^)
+THE_UNIQUE_SPREADSHEET_ID = "1ej9FnOtxSjNSMEzYAZUwWx9hIAIrhw-5G6l8w_GoXnU"
+THE_UNIQUE_ROSTER_SHEET = "EVENTS"
+
+
+def get_default_sheet_handler() -> EventSpreadsheet:
+    """Returns the default spreadsheet to use in this context."""
+    return EventSpreadsheet(get_handler().spreadsheets(),
+                            THE_UNIQUE_SPREADSHEET_ID,
+                            THE_UNIQUE_ROSTER_SHEET)

--- a/event/sheet_integration_test.py
+++ b/event/sheet_integration_test.py
@@ -1,0 +1,40 @@
+"""Integration with Google Sheets, storing the events."""
+
+from __future__ import annotations
+
+__LICENSE__ = """
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+from event.sheet_integration import column_offset
+
+
+class EventSpreadsheetTest(unittest.TestCase):
+    """Unit tests for the event spreadsheet integration."""
+
+    def test_column_offset(self):
+        """Tests Google Sheets' column offsets are well calculated."""
+        self.assertEqual(column_offset('A'), 0)
+        self.assertEqual(column_offset('D'), 3)
+        self.assertEqual(column_offset('AA'), 26)
+        self.assertEqual(column_offset('AD'), 29)
+        self.assertEqual(column_offset('BA'), 52)
+        self.assertEqual(column_offset('BD'), 55)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Database
 datetime
+python-dateutil
 discord
 pytz
 tinydb_serialization

--- a/roster/model.py
+++ b/roster/model.py
@@ -143,6 +143,10 @@ class Player:
         self.discord_uuid = discord_uuid
         self.characters = characters is not None and characters or []
 
+    def __repr__(self):
+        return '<Player {} ({} characters)>'.format(
+            self.discord_handle, len(self.characters))
+
     def get_playable_roles(self) -> Set[CharacterRole]:
         """Returns all the roles the player is able to play."""
         roles = set()

--- a/roster/sheet_integration.py
+++ b/roster/sheet_integration.py
@@ -88,7 +88,7 @@ class RosterSpreadsheet:
             if len(row) < self.MANAGED_COLUMNS:
                 # Incomplete inputs.
                 continue
-            [handle, uid, server, name, klass_name] = row[:5]
+            handle, uid, server, name, klass_name = row[:self.MANAGED_COLUMNS]
             if not (handle and uid and server and name and klass_name):
                 # Incomplete inputs.
                 continue
@@ -166,7 +166,7 @@ THE_UNIQUE_SPREADSHEET_ID = "1ej9FnOtxSjNSMEzYAZUwWx9hIAIrhw-5G6l8w_GoXnU"
 THE_UNIQUE_ROSTER_SHEET = "ROSTER"
 
 
-def get_default_sheet_handler():
+def get_default_roster_sheet_handler():
     """Returns the default spreadsheet to use in this context."""
     return RosterSpreadsheet(get_sheets_handler().spreadsheets(),
                              THE_UNIQUE_SPREADSHEET_ID,


### PR DESCRIPTION
Basically use Google Sheet to store events. It's not really ideal but at least we have a consistent source of data.

This will help tracking attendance over a tier, as well as attendance to a specific event.

Sheet for reference: https://docs.google.com/spreadsheets/d/1ej9FnOtxSjNSMEzYAZUwWx9hIAIrhw-5G6l8w_GoXnU/edit#gid=1998705599

Example output of the print_events.py script:

```
New players added from the roster:  ['Bob#1234']
INFO:root:Attendance for event <Event "Hero raid" 2020-01-02T21:00:00+00:00>: {<Player Foo#1234 (2 characters)>: <Availability SIGNED>}
INFO:root:Attendance for event <Event "Mythicc Raiding" 2020-01-01T21:00:00+00:00>: {}
Date                       Title            Description                      Availabilities
-------------------------  ---------------  -------------------------------  ---------------------------------------------------------
2020-01-02T21:00:00+00:00  Hero raid        Blablabla                        {<Player Foo#1234 (2 characters)>: <Availability SIGNED>}
2020-01-01T21:00:00+00:00  Mythicc Raiding  Bring consumable, good gear etc  {}
```