### PR TITLE
Remove the /static/ prefix in the route when serving Angular through Flask

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -37,7 +37,7 @@ if debug:
         return response
 
 
-@app.route('/<path:path>', methods=['GET'])
+@app.route('/<path:path>')
 def frontend_proxy(path):
     """Serves the unbound paths from the Angular compiled directory."""
     return send_from_directory('./web/dist', path)

--- a/ui/app.py
+++ b/ui/app.py
@@ -18,15 +18,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from flask import Flask, render_template
+from flask import Flask, render_template, send_from_directory
 
 app = Flask(__name__)
 
 
-@app.route('/', methods=['GET'])
+@app.route('/<path:path>', methods=['GET'])
+def frontend_proxy(path):
+    """Serves the unbound paths from the Angular compiled directory."""
+    return send_from_directory('./web/dist', path)
+
+
+@app.route('/')
 def root():
     """Serves the root index file."""
-    return render_template('index.html')
+    return send_from_directory('./web/dist', 'index.html')
 
 
 @app.errorhandler(500)

--- a/ui/app.py
+++ b/ui/app.py
@@ -20,7 +20,21 @@ limitations under the License.
 
 from flask import Flask, render_template, send_from_directory
 
+from config.flask import secret_key, debug
+
 app = Flask(__name__)
+app.secret_key = secret_key
+
+
+# Prevent cached response when running in debug mode, so we can easily
+# rebuild on change and see the differences.
+if debug:
+    @app.after_request
+    def after_request(response):
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, public, max-age=0"
+        response.headers["Expires"] = 0
+        response.headers["Pragma"] = "no-cache"
+        return response
 
 
 @app.route('/<path:path>', methods=['GET'])

--- a/ui/build.py
+++ b/ui/build.py
@@ -52,7 +52,7 @@ def build_angular(dev_mode: bool):
 
     # Build the angular application in dev/prod mode.
     args = [
-        'ng', 'build', '--build-optimizer', '--aot', '--baseHref=/static/']
+        'ng', 'build', '--build-optimizer', '--aot']
     if not dev_mode:
         args.append('--prod')
     build = subprocess.run(args, cwd=WEB_DIRECTORY)
@@ -60,8 +60,3 @@ def build_angular(dev_mode: bool):
         raise RuntimeError(
             'Failed to build the Angular application. Check the above '
             'logs for further details.')
-
-    # Finally, move the generated index.html file in the templates.
-    static_index_file = os.path.join(THIS_DIRECTORY, 'static', 'index.html')
-    template_index_file = os.path.join(THIS_DIRECTORY, 'templates', 'index.html')
-    os.replace(static_index_file, template_index_file)

--- a/ui/web/angular.json
+++ b/ui/web/angular.json
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "../static",
+            "outputPath": "./dist",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",


### PR DESCRIPTION
Development setup.

Basically this removes the http://\<host\>:\<port\>/**static/** part of the URL, which happen to cause some issues when trying to develop.

This is way easier to manage development when everything is served from the same endpoint as OAuth2 authentication is tricky to do when serving the frontend from a different binary than the backend.

On the long run, we'll serve everything through a single endpoint with Nginx doing the reverse proxy. That way OAuth2 should be trivial to do since the request is coming from the same endpoint, but routed in different location depending on NGinx Authentication. Maybe. Or maybe my understanding of how OAuth2 is working is completely broken \<insert pepega emote\>