### PR TITLE
Only return guilds the user AND the bot are part of

### DIFF
--- a/ui/mod_user/controllers.py
+++ b/ui/mod_user/controllers.py
@@ -17,8 +17,8 @@ limitations under the License.
 
 from flask import Blueprint, jsonify
 
-from config.discord import api_base_url
 from ui.mod_auth.session import get_discord_session
+from ui.mod_user.user import User
 
 mod_user = Blueprint('user', __name__, url_prefix='/api/user')
 
@@ -26,7 +26,6 @@ mod_user = Blueprint('user', __name__, url_prefix='/api/user')
 @mod_user.route('/')
 def user():
     """Returns the Discord information about this user."""
-    discord = get_discord_session()
-    user = discord.get(api_base_url + '/users/@me').json()
-    guilds = discord.get(api_base_url + '/users/@me/guilds').json()
-    return jsonify(user=user, guilds=guilds)
+    discord_session = get_discord_session()
+    user = User.from_oauth_discord(discord_session)
+    return jsonify(user.to_dict())

--- a/ui/mod_user/user.py
+++ b/ui/mod_user/user.py
@@ -1,4 +1,4 @@
-"""Database model declaration for a guild and a WoW guild."""
+"""Database model declaration for an application user."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ import discord
 from enum import Enum
 from flask_sqlalchemy import BaseQuery
 from requests_oauthlib import OAuth2Session
-from typing import List, Dict, Optional
+from typing import List, Optional
 
 from config.discord import api_base_url
 from ui.base import db, BaseSerializerMixin

--- a/ui/mod_user/user.py
+++ b/ui/mod_user/user.py
@@ -70,8 +70,10 @@ class User(db.Model, BaseSerializerMixin):
     :attr id: Discord user's unique ID, used as primary key for storage.
     :attr date_created: The moment the guild was registered in our storage.
     :attr date_modified: The last update performed on our storage.
-    :attr icon_href: Address of the Discord Icon representing this server.
-    :attr bot_present: Whether the bot is present in the discord guild.
+    :attr username: The Discord username.
+    :attr discriminator: The 4 digit string allowing to make friend request.
+    :attr avatar: User's avatar ID.
+    :attr relationships: List of guild the user is part of.
     """
     __tablename__ = 'user'
 

--- a/ui/mod_user/user.py
+++ b/ui/mod_user/user.py
@@ -1,0 +1,157 @@
+"""Database model declaration for a guild and a WoW guild."""
+
+from __future__ import annotations
+
+__LICENSE__ = """
+Copyright 2019 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import discord
+
+from enum import Enum
+from flask_sqlalchemy import BaseQuery
+from requests_oauthlib import OAuth2Session
+from typing import List, Dict, Optional
+
+from config.discord import api_base_url
+from ui.base import db, BaseSerializerMixin
+from ui.mod_guild.guild import Guild
+
+
+class Permission(Enum):
+    """Permission level of a user in regards of a guild."""
+    none = 'NONE'
+    visible = 'VISIBLE'
+    owner = 'OWNER'
+
+    @classmethod
+    def _missing_(cls, unused_value):
+        """If the permission identifier is missing, assume it is none."""
+        return cls.none
+
+
+class UserInGuild(db.Model, BaseSerializerMixin):
+    """Creates a relationship between an user and a guild."""
+    __tablename__ = 'user_in_guild'
+
+    serialize_rules = (
+        # Avoid duplicated entries.
+        '-user_id', '-guild_id',
+    )
+
+    user_id = db.Column('user_id', db.Integer,
+                        db.ForeignKey('user.id'), primary_key=True)
+    guild_id = db.Column('guild_id', db.Integer,
+                         db.ForeignKey('guild.id'), primary_key=True)
+
+    user = db.relationship('User', uselist=False)
+    guild = db.relationship('Guild', uselist=False)
+
+    permission = db.Column(db.Enum(Permission))
+
+    def __init__(self, user: User, guild: Guild, permission=Permission.none):
+        self.user_id = user.id
+        self.guild_id = guild.id
+        self.permission = permission
+
+
+class User(db.Model, BaseSerializerMixin):
+    """A Discord user.
+
+    :attr id: Discord user's unique ID, used as primary key for storage.
+    :attr date_created: The moment the guild was registered in our storage.
+    :attr date_modified: The last update performed on our storage.
+    :attr icon_href: Address of the Discord Icon representing this server.
+    :attr bot_present: Whether the bot is present in the discord guild.
+    """
+    __tablename__ = 'user'
+
+    # Automatically created by db.Model but clarifying existence for mypy.
+    query: BaseQuery
+
+    # Serialization options
+    serialize_rules = (
+        # Fields computed from the record.
+        'icon_url',
+        # Fields not exposed to the frontend.
+        '-date_created', '-date_modified', '-avatar',
+        # Avoid circular dependencies.
+        '-relationships.user', '-relationships.guild.users',
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    date_created = db.Column(
+        db.DateTime,
+        default=db.func.current_timestamp())
+    date_modified = db.Column(
+        db.DateTime,
+        default=db.func.current_timestamp(),
+        onupdate=db.func.current_timestamp())
+
+    username = db.Column(db.String)
+    discriminator = db.Column(db.String)
+    avatar = db.Column(db.String)
+
+    # Relationships
+    relationships = db.relationship('UserInGuild', uselist=True)
+
+    def __init__(self, id: int):
+        self.id = id
+
+    @property
+    def icon_url(self) -> Optional[str]:
+        """Returns the URL to the icon of the user, if any."""
+        if self.avatar is None:
+            return None
+        url = f'/avatars/{self.id}/{self.avatar}.png?size=1024'
+        return str(discord.Asset(state=None, url=url))
+
+    @classmethod
+    def from_oauth_discord(cls, session: OAuth2Session):
+        """Gets the values from the Discord record of a guild."""
+        oauth_user = session.get(api_base_url + '/users/@me').json()
+        # Try to retrieve the latest record of the user, otherwise
+        # create a record.
+        id = int(oauth_user.get('id'))
+        user = cls.query.filter_by(id=id).one_or_none()
+        if user is None:
+            user = cls(id)
+        user.username = oauth_user.get('username')
+        user.discriminator = oauth_user.get('discriminator')
+        user.avatar = oauth_user.get('avatar')
+        user.resync_guild_relationships(session)
+        return user
+
+    def resync_guild_relationships(self, session: OAuth2Session):
+        """Re-syncs the relationships of a user to its guilds."""
+        oauth_guilds = session.get(api_base_url + '/users/@me/guilds').json()
+        oauth_by_id = {g.get('id'): g for g in oauth_guilds}
+
+        relationships: List[UserInGuild] = []
+
+        # Get the stored guilds matching with the ones the user belongs to
+        # and refresh the relationship.
+        matching = Guild.query.filter(Guild.id.in_(
+            tuple(oauth_by_id.keys()))).all()
+        for guild in matching:
+            oauth_guild = oauth_by_id[str(guild.id)]
+            permission = Permission.visible
+            if oauth_guild.get('owner'):
+                permission = Permission.owner
+            relationships.append(UserInGuild(self, guild, permission))
+
+        # User is now complete. Remove all previous relationships and
+        # update them.
+        db.session.query(UserInGuild).filter_by(user_id=self.id).delete()
+        db.session.add(self)
+        db.session.add_all(relationships)
+        db.session.commit()

--- a/ui/web/src/app/app.component.html
+++ b/ui/web/src/app/app.component.html
@@ -5,7 +5,7 @@
 </main>
 
 <h1>User info</h1>
-<pre *ngIf="profile$ | async as profile">{{profile.user | json}}</pre>
+<pre *ngIf="profile$ | async as profile">{{profile | json}}</pre>
 <h1>Selected guild</h1>
 <pre *ngIf="selectedGuild">{{selectedGuild | json}}</pre>
 <a routerLink="/demo/styles-palette" routerLinkActive="active">Styles</a>

--- a/ui/web/src/app/header/header.component.html
+++ b/ui/web/src/app/header/header.component.html
@@ -5,18 +5,18 @@
   <ng-container *ngIf="profile">
     <button mat-button [matMenuTriggerFor]="guildMenu" class="guild-selection">
       <div class="button-wrapper">
-        <discord-icon type="icons" [id]="selectedGuild?.id" [icon]="selectedGuild?.icon"></discord-icon>
-        <span>{{ selectedGuild?.name }}</span>
+        <img [src]="selectedGuild?.icon_href" />
+        <span>{{ selectedGuild?.discord_name }}</span>
         <mat-icon class="subtle">keyboard_arrow_down</mat-icon>
       </div>
     </button>
     <mat-menu #guildMenu="matMenu">
-      <button *ngFor="let guild of profile.guilds; trackBy: trackByGuildId"
-              (click)="onGuildSelected(guild)"
+      <button *ngFor="let relationship of profile.relationships || []; trackBy: trackByGuildId"
+              (click)="onGuildSelected(relationship)"
               mat-menu-item>
         <div class="button-wrapper">
-          <discord-icon type="icons" [id]="guild.id" [icon]="guild.icon"></discord-icon>
-          <span>{{ guild.name }}</span>
+          <img [src]="relationship.guild?.icon_href" />
+          <span>{{ relationship.guild?.discord_name }}</span>
         </div>
       </button>
     </mat-menu>
@@ -25,7 +25,7 @@
   <ng-container *ngIf="profile; else login">
     <button mat-button [matMenuTriggerFor]="userMenu" class="user-profile">
       <div class="button-wrapper">
-        <discord-icon type="avatars" [id]="profile.user?.id" [icon]="profile.user?.avatar"></discord-icon>
+        <img [src]="profile.icon_url" />
         <mat-icon class="subtle">keyboard_arrow_down</mat-icon>
       </div>
     </button>

--- a/ui/web/src/app/header/header.component.scss
+++ b/ui/web/src/app/header/header.component.scss
@@ -51,7 +51,7 @@ mat-toolbar {
   display: flex;
   align-items: center;
 
-  discord-icon {
+  img {
     margin: 0 6px 0 -4px;
     width: 24px;
     height: 24px;
@@ -71,12 +71,12 @@ mat-toolbar {
     }
   }
 
-  discord-icon:last-child,
+  img:last-child,
   mat-icon:last-child {
     margin-right: -4px;
   }
 
-  discord-icon:first-child,
+  img:first-child,
   mat-icon:first-child {
     margin-left: -4px;
   }

--- a/ui/web/src/app/header/header.component.spec.ts
+++ b/ui/web/src/app/header/header.component.spec.ts
@@ -48,8 +48,8 @@ describe('HeaderComponent', () => {
 
   it('displays the user avatar instead of the login button after auth', () => {
     const profile: UserProfile = {
-      guilds: [],
-      user: {id: '123', avatar: '456'},
+      id: 123,
+      icon_url: 'https://something.com/123',
     };
     component.profile = profile;
     fixture.detectChanges();
@@ -57,12 +57,20 @@ describe('HeaderComponent', () => {
     expect(fixture.nativeElement.querySelector('a.login')).toBeNull();
     const userButton = fixture.nativeElement.querySelector('button.user-profile');
     expect(userButton).not.toBeNull();
-    expect(userButton.querySelector('discord-icon img')).not.toBeNull();
+    expect(userButton.querySelector('img')).not.toBeNull();
   });
 
   it('selects a guild by default if none are selected', fakeAsync(() => {
     const profile: UserProfile = {
-      guilds: [{id: '123', name: 'My amazing guild', icon: '456'}],
+      relationships: [
+        {
+          guild: {
+            id: 123,
+            discord_name: 'My amazing guild',
+            icon_href: 'https://something.com/123',
+          },
+        },
+      ],
     };
     component.profile = profile;
     component.ngOnChanges();
@@ -72,7 +80,7 @@ describe('HeaderComponent', () => {
 
     const guildSelector = fixture.nativeElement.querySelector('button.guild-selection');
     expect(guildSelector).not.toBeNull();
-    expect(guildSelector.querySelector('discord-icon img')).not.toBeNull();
+    expect(guildSelector.querySelector('img')).not.toBeNull();
     expect(guildSelector.textContent).toContain('My amazing guild');
   }));
 });

--- a/ui/web/src/app/header/header.component.ts
+++ b/ui/web/src/app/header/header.component.ts
@@ -62,6 +62,6 @@ export class HeaderComponent implements OnChanges {
   }
 
   trackByGuildId(index: number, relationship: GuildRelationship): string {
-    return relationship.guild?.id ?? '';
+    return String(relationship.guild?.id ?? '');
   }
 }

--- a/ui/web/src/app/header/header.component.ts
+++ b/ui/web/src/app/header/header.component.ts
@@ -15,22 +15,22 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
-import { Router } from '@angular/router';
+import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
+import {Router} from '@angular/router';
 
-import { UserService, UserProfile, Guild, GuildRelationship } from 'src/app/user/user.service';
+import {UserService, UserProfile, Guild, GuildRelationship} from 'src/app/user/user.service';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.scss']
+  styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnChanges {
   @Input() profile?: UserProfile;
   @Input() selectedGuild?: Guild;
   @Output() selectedGuildChange = new EventEmitter<Guild>();
 
-  constructor(private readonly router: Router, private readonly userService: UserService) { }
+  constructor(private readonly router: Router, private readonly userService: UserService) {}
 
   ngOnChanges() {
     const guilds = this.profile?.relationships ?? [];
@@ -47,7 +47,7 @@ export class HeaderComponent implements OnChanges {
 
   onGuildSelected(relationship: GuildRelationship) {
     if (!relationship.guild) {
-       return;
+      return;
     }
     if (this.selectedGuild?.id !== relationship.guild.id) {
       this.selectedGuild = relationship.guild;
@@ -57,7 +57,7 @@ export class HeaderComponent implements OnChanges {
 
   logoutUser() {
     this.userService.logout().subscribe(() => {
-      this.router.navigate(['/'], {queryParams: {'refresh': 1}});
+      this.router.navigate(['/'], {queryParams: {refresh: 1}});
     });
   }
 

--- a/ui/web/src/app/header/header.module.ts
+++ b/ui/web/src/app/header/header.module.ts
@@ -22,13 +22,11 @@ import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatMenuModule} from '@angular/material/menu';
 
-import {DiscordModule} from '../discord/discord.module';
-
 import {HeaderComponent} from './header.component';
 
 @NgModule({
   declarations: [HeaderComponent],
   exports: [HeaderComponent],
-  imports: [CommonModule, DiscordModule, MatButtonModule, MatIconModule, MatMenuModule, MatToolbarModule],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatToolbarModule],
 })
 export class HeaderModule {}

--- a/ui/web/src/app/user/user.service.ts
+++ b/ui/web/src/app/user/user.service.ts
@@ -20,23 +20,33 @@ import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {map, mapTo} from 'rxjs/operators';
 
+/** Permission level of an user over a guild. */
+export declare enum Permission {
+  NONE = 'NONE',
+  VISIBLE = 'VISIBLE',
+  OWNER = 'OWNER',
+}
+
 /** A Discord guild information. */
-export interface Guild {
+export declare interface Guild {
   id?: string;
   name?: string;
   icon?: string;
+  is_owner?: boolean;
 }
 
-/** A Discord user information. */
-export interface User {
-  id?: string;
-  avatar?: string;
+export declare interface GuildRelationship {
+  guild?: Guild;
+  permission?: Permission;
 }
 
-/** High level information about an user. */
-export interface UserProfile {
-  guilds?: Guild[];
-  user?: User;
+/** A Discord user. */
+export declare interface UserProfile {
+  id?: number;
+  username?: string;
+  discriminator?: string;
+  icon_url?: string;
+  relationships?: GuildRelationship[];
 }
 
 /** Response to the authentication check. */

--- a/ui/web/src/app/user/user.service.ts
+++ b/ui/web/src/app/user/user.service.ts
@@ -29,10 +29,9 @@ export declare enum Permission {
 
 /** A Discord guild information. */
 export declare interface Guild {
-  id?: string;
-  name?: string;
-  icon?: string;
-  is_owner?: boolean;
+  id?: number;
+  discord_name?: string;
+  icon_href?: string;
 }
 
 export declare interface GuildRelationship {


### PR DESCRIPTION
Before, the `/api/user` route was yielding all the guilds the user was part of. Instead only yield the guilds where both the user and the bot are present.