### PR TITLE
Remove the hashtag-based routing in Angular in favor of cleaner routes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ python-wowapi
 flask
 flask_sqlalchemy
 sqlalchemy_serializer
+werkzeug
 
 # For scripts
 tabulate

--- a/ui/app.py
+++ b/ui/app.py
@@ -20,33 +20,17 @@ limitations under the License.
 
 from flask import send_from_directory, render_template
 
-from config.flask import debug
 from ui.base import app, db
 from ui.mod_auth.controllers import mod_auth
-from ui.mod_user.controllers import mod_user
+from ui.mod_frontend.controllers import mod_frontend
 from ui.mod_guild.controllers import mod_guild
+from ui.mod_user.controllers import mod_user
 
 db.init_app(app)
 app.register_blueprint(mod_auth)
-app.register_blueprint(mod_user)
+app.register_blueprint(mod_frontend)
 app.register_blueprint(mod_guild)
-
-
-# Prevent cached response when running in debug mode, so we can easily
-# rebuild on change and see the differences.
-if debug:
-    @app.after_request
-    def after_request(response):
-        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, public, max-age=0"
-        response.headers["Expires"] = 0
-        response.headers["Pragma"] = "no-cache"
-        return response
-
-
-@app.route('/<path:path>')
-def frontend_proxy(path):
-    """Serves the unbound paths from the Angular compiled directory."""
-    return send_from_directory('./web/dist', path)
+app.register_blueprint(mod_user)
 
 
 @app.route('/')

--- a/ui/mod_frontend/controllers.py
+++ b/ui/mod_frontend/controllers.py
@@ -1,0 +1,48 @@
+"""Controller utilities for authentication through Discord."""
+
+from __future__ import annotations
+
+__LICENSE__ = """
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from flask import Blueprint, send_from_directory
+from werkzeug.exceptions import NotFound
+
+from config.flask import debug
+
+mod_frontend = Blueprint('frontend', __name__)
+
+
+# Prevent cached response when running in debug mode, so we can easily
+# rebuild on change and see the differences.
+if debug:
+    @mod_frontend.after_request
+    def after_request(response):
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, public, max-age=0"
+        response.headers["Expires"] = 0
+        response.headers["Pragma"] = "no-cache"
+        return response
+
+
+@mod_frontend.route('/<path:path>')
+def frontend_proxy(path):
+    """Serves the unbound paths from the Angular compiled directory."""
+    try:
+        return send_from_directory('./web/dist', path)
+    except NotFound:
+        # Fallback to the index.html. It is fairly possible the requested route
+        # is the result of Angular attempting to route to itself.
+        return send_from_directory('./web/dist', 'index.html')

--- a/ui/mod_frontend/controllers.py
+++ b/ui/mod_frontend/controllers.py
@@ -43,6 +43,6 @@ def frontend_proxy(path):
     try:
         return send_from_directory('./web/dist', path)
     except NotFound:
-        # Fallback to the index.html. It is fairly possible the requested route
-        # is the result of Angular attempting to route to itself.
+        # Fallback to the index.html. The requested route might be the
+        # result of how the Angular router is implementing its routes.
         return send_from_directory('./web/dist', 'index.html')

--- a/ui/web/src/app/app-routing.module.ts
+++ b/ui/web/src/app/app-routing.module.ts
@@ -26,7 +26,7 @@ import {LandingModule} from './landing/landing.module';
 const routes: Routes = [{path: 'demo/styles-palette', component: StylesDemoComponent}];
 
 @NgModule({
-  imports: [DemoModule, LandingModule, RouterModule.forRoot(routes, {useHash: true})],
+  imports: [DemoModule, LandingModule, RouterModule.forRoot(routes)],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
Basically, `http://app.com/#/some/angular/route` becomes `http://app.com/some/angular/route`.

Also move the frontend-related routes into their own module.