### PR TITLE
api/get-or-create Add method to get wow objects from the DB or create them from the API

### DIFF
--- a/api/mod_user/controllers.py
+++ b/api/mod_user/controllers.py
@@ -22,6 +22,8 @@ from config.blizzard import get_wow_handler
 from api.mod_auth.session import get_discord_session
 from api.mod_user.user import User, UserOwnsCharacters
 from api.mod_user.forms import CharacterAssociationForm
+from api.mod_wow.character import WowCharacter
+from api.mod_wow.realm import WowRealm
 
 mod_user = Blueprint('user', __name__, url_prefix='/api/user')
 
@@ -42,7 +44,9 @@ def add_character(user_id: str):
     if not form.validate():
         return jsonify(error='Invalid request', form_errors=form.errors), 400
 
-    character = form.get_character(get_wow_handler())
+    handler = get_wow_handler()
+    realm = WowRealm.get_or_create(handler, form.region.data, form.realm_slug.data)
+    character = WowCharacter.get_or_create(handler, realm, form.character_slug.data)
     user = User.query.filter_by(id=user_id).one_or_none()
     if user is None:
         return jsonify(error='User not found'), 404

--- a/api/mod_user/forms.py
+++ b/api/mod_user/forms.py
@@ -15,14 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from wowapi import WowApi
-
 from api.common.forms import EnumField
 from wtforms import Form, StringField
 
 from api.mod_wow.region import Region
-from api.mod_wow.character import WowCharacter
-from api.mod_wow.realm import WowRealm
 
 
 class CharacterAssociationForm(Form):
@@ -30,19 +26,3 @@ class CharacterAssociationForm(Form):
     region = EnumField('Repetition frequency', enum=Region)
     character_slug = StringField('Character Slug')
     realm_slug = StringField('Realm Slug')
-
-    def get_character(self, handler: WowApi) -> WowCharacter:
-        """Converts the data provided in the form to an event."""
-        realm = WowRealm.query.filter_by(
-            region=self.region.data, slug=self.realm_slug.data).one_or_none()
-        if realm is None:
-            realm = WowRealm.create_from_api(
-                handler, self.region.data, self.realm_slug.data)
-
-        character = WowCharacter.query.filter_by(
-            realm_id=realm.id, name=self.character_slug.data).one_or_none()
-        if character is None:
-            character = WowCharacter.create_from_api(
-                handler, realm, self.character_slug.data)
-
-        return character

--- a/api/mod_user/user_test.py
+++ b/api/mod_user/user_test.py
@@ -129,9 +129,7 @@ class TestUser(DatabaseTestFixture, unittest.TestCase):
     def test_can_own_one_character(self):
         """Checks if the user can own a single character."""
         self.db.session.add(User('123456789'))
-        self.db.session.add(
-            WowCharacter('987654321', 'Funkypewpew', 13,
-                         WowFaction.alliance, 13, 13, 13, 13))
+        self.db.session.add(WowCharacter(id='987654321', name='Funkypewpew'))
 
         relationship = UserOwnsCharacters('123456789', '987654321')
         self.db.session.add(relationship)
@@ -139,3 +137,4 @@ class TestUser(DatabaseTestFixture, unittest.TestCase):
         actual = User.query.filter_by(id='123456789').first()
         self.assertEqual(len(actual.characters), 1)
         self.assertEqual(actual.characters[0].character.id, '987654321')
+        self.assertEqual(actual.characters[0].character.name, 'Funkypewpew')

--- a/api/mod_wow/character.py
+++ b/api/mod_wow/character.py
@@ -74,13 +74,14 @@ class WowCharacter(db.Model, BaseSerializerMixin):
         data = handler.get_character_profile_summary(
             realm.region.value, realm.region.profile_namespace, realm.slug,
             name, locale='en_US')
+        klass = WowPlayableClass.get_or_create(handler, data['character_class']['id'])
         return cls(
             id=str(data['id']),
             name=data['name'],
             realm_id=realm.id,
             realm=realm,
             faction=WowFaction(data['faction']['type']),
-            klass_id=data['character_class']['id'],
+            klass=klass,
             active_spec_id=data['active_spec']['id'],
             average_ilvl=data['average_item_level'],
             equipped_ilvl=data['equipped_item_level'])

--- a/api/mod_wow/character_test.py
+++ b/api/mod_wow/character_test.py
@@ -20,6 +20,7 @@ import json
 import os
 import unittest.mock
 
+from api.common.testing import DatabaseTestFixture
 from api.mod_wow.character import WowCharacter
 from api.mod_wow.region import Region
 from api.mod_wow.realm import WowRealm
@@ -31,7 +32,7 @@ TESTDATA_DIR = os.path.join(
     'testdata')
 
 
-class TestWowPlayableSpecModel(unittest.TestCase):
+class TestWowPlayableSpecModel(DatabaseTestFixture, unittest.TestCase):
     """Checks creation of a wow playable spec."""
 
     @classmethod
@@ -46,11 +47,13 @@ class TestWowPlayableSpecModel(unittest.TestCase):
         mock = unittest.mock.MagicMock()
         mock.get_character_profile_summary.return_value = self.CHARACTER_DATA
 
-        realm = WowRealm(536, 'Argent Dawn', 'argent-dawn', Region.eu, 'Europe/Paris')
+        realm = WowRealm(id=536, region=Region.eu, name='Argent Dawn',
+                         slug='argent-dawn', timezone_name='Europe/Paris')
         character = WowCharacter.create_from_api(mock, realm, 'Funkypewpew')
 
-        mock.get_character_profile_summary.assert_called_with('eu', 'profile-eu', 'argent-dawn', 'Funkypewpew', locale='en_US')
-        self.assertEqual(character.id, 146666340)
+        mock.get_character_profile_summary.assert_called_with(
+            'eu', 'profile-eu', 'argent-dawn', 'Funkypewpew', locale='en_US')
+        self.assertEqual(character.id, '146666340')
         self.assertEqual(character.name, 'Funkypewpew')
         self.assertEqual(character.realm_id, 536)
         self.assertEqual(character.faction, WowFaction.alliance)
@@ -58,3 +61,30 @@ class TestWowPlayableSpecModel(unittest.TestCase):
         self.assertEqual(character.active_spec_id, 253)
         self.assertEqual(character.average_ilvl, 136)
         self.assertEqual(character.equipped_ilvl, 135)
+
+    def test_get_or_create_queries_api(self):
+        """Tests the character is queried if not available in database."""
+        mock = unittest.mock.MagicMock()
+        mock.get_character_profile_summary.return_value = self.CHARACTER_DATA
+
+        realm = WowRealm(id=536, region=Region.eu, slug='argent-dawn')
+        character = WowCharacter.get_or_create(mock, realm, 'Funkypewpew')
+
+        mock.get_character_profile_summary.assert_called_with(
+            'eu', 'profile-eu', 'argent-dawn', 'Funkypewpew', locale='en_US')
+        self.assertEqual(character.id, '146666340')
+        self.assertEqual(character.name, 'Funkypewpew')
+
+    def test_get_or_create_uses_cache(self):
+        """Tests the character is queried from database if available there."""
+        mock = unittest.mock.MagicMock()
+        mock.get_character_profile_summary.return_value = self.CHARACTER_DATA
+        realm = WowRealm(id=536, region=Region.eu, slug='argent-dawn')
+        stored_character = WowCharacter(id='123456', name='Funkypewpew', realm_id=realm.id, realm=realm)
+        self.db.session.add(stored_character)
+
+        character = WowCharacter.get_or_create(mock, realm, 'Funkypewpew')
+
+        mock.get_character_profile_summary.assert_not_called()
+        self.assertEqual(character.id, '123456')
+        self.assertEqual(character.name, 'Funkypewpew')

--- a/api/mod_wow/static_test.py
+++ b/api/mod_wow/static_test.py
@@ -20,6 +20,7 @@ import json
 import os
 import unittest.mock
 
+from api.common.testing import DatabaseTestFixture
 from api.mod_wow.static import WowRole, WowPlayableClass, WowPlayableSpec
 
 
@@ -28,7 +29,7 @@ TESTDATA_DIR = os.path.join(
     'testdata')
 
 
-class TestWowPlayableSpecModel(unittest.TestCase):
+class TestWowPlayableSpecModel(DatabaseTestFixture, unittest.TestCase):
     """Checks creation of a wow playable spec."""
 
     @classmethod
@@ -50,8 +51,32 @@ class TestWowPlayableSpecModel(unittest.TestCase):
         self.assertEqual(spec.name, 'Brewmaster')
         self.assertEqual(spec.role, WowRole.tank)
 
+    def test_get_or_create_queries_api(self):
+        """Tests the realm is queried if not available in database."""
+        mock = unittest.mock.MagicMock()
+        mock.get_playable_specialization.return_value = self.BREWMASTER_SPEC_DATA
 
-class TestWowPlayableClassModel(unittest.TestCase):
+        spec = WowPlayableSpec.get_or_create(mock, 268)
+
+        mock.get_playable_specialization.assert_called_with('us', 'static-us', 268, locale='en_US')
+        self.assertEqual(spec.id, 268)
+        self.assertEqual(spec.name, 'Brewmaster')
+        self.assertEqual(spec.role, WowRole.tank)
+
+    def test_get_or_create_uses_cache(self):
+        """Tests the realm is queried from database if available there."""
+        mock = unittest.mock.MagicMock()
+        mock.get_playable_specialization.return_value = self.BREWMASTER_SPEC_DATA
+        stored_spec = WowPlayableSpec(id=268, name='Brewmaster', role=WowRole.tank)
+        self.db.session.add(stored_spec)
+
+        spec = WowPlayableSpec.get_or_create(mock, 268)
+
+        mock.get_realm.assert_not_called()
+        self.assertEqual(spec.id, 268)
+
+
+class TestWowPlayableClassModel(DatabaseTestFixture, unittest.TestCase):
     """Checks creation of a wow playable spec."""
 
     @classmethod
@@ -71,18 +96,51 @@ class TestWowPlayableClassModel(unittest.TestCase):
                                'get_playable_spec__270.json')) as f:
             cls.MONK_SPECS_DATA[270] = json.load(f)
 
-    def test_create_playable_class_from_api(self):
-        """Test creation from the WoW API results."""
+    def create_mock_api(self) -> unittest.mock.MagicMock:
+        """Creates a mock API providing data about the Monk class."""
         def playable_spec_wrapper(unused_region, unused_profile, id, *args, **kwargs):
             return self.MONK_SPECS_DATA[id]
 
         mock = unittest.mock.MagicMock()
         mock.get_playable_specialization.side_effect = playable_spec_wrapper
         mock.get_playable_class.return_value = self.MONK_CLASS_DATA
+        return mock
+
+    def test_create_playable_class_from_api(self):
+        """Test creation from the WoW API results."""
+        mock = self.create_mock_api()
 
         klass = WowPlayableClass.create_from_api(mock, 10)
 
         mock.get_playable_class.assert_called_with('us', 'static-us', 10, locale='en_US')
+        self.assertEqual(klass.id, 10)
+        self.assertEqual(klass.name, 'Monk')
+        self.assertEqual([s.name for s in klass.specs], ['Brewmaster', 'Windwalker', 'Mistweaver'])
+
+    def test_get_or_create_queries_api(self):
+        """Tests the realm is queried if not available in database."""
+        mock = self.create_mock_api()
+
+        klass = WowPlayableClass.get_or_create(mock, 10)
+
+        mock.get_playable_class.assert_called_with('us', 'static-us', 10, locale='en_US')
+        self.assertEqual(klass.id, 10)
+        self.assertEqual(klass.name, 'Monk')
+        self.assertEqual([s.name for s in klass.specs], ['Brewmaster', 'Windwalker', 'Mistweaver'])
+
+    def test_get_or_create_uses_cache(self):
+        """Tests the realm is queried from database if available there."""
+        mock = self.create_mock_api()
+        stored_class = WowPlayableClass(id=10, name='Monk', specs=[
+            WowPlayableSpec(id=268, name='Brewmaster'),
+            WowPlayableSpec(id=269, name='Windwalker'),
+            WowPlayableSpec(id=270, name='Mistweaver')
+        ])
+        self.db.session.add(stored_class)
+
+        klass = WowPlayableClass.get_or_create(mock, 10)
+
+        mock.get_playable_class.assert_not_called()
         self.assertEqual(klass.id, 10)
         self.assertEqual(klass.name, 'Monk')
         self.assertEqual([s.name for s in klass.specs], ['Brewmaster', 'Windwalker', 'Mistweaver'])


### PR DESCRIPTION
This allows to properly plumb things in a test environment.

Ideally all static objects (e.g. playable class) and realm data should be preloaded using the `preload_data.py`, however since we do need to modify a lot the DB and re-create it a lot in development cycle, this ends up consuming the Blizzard's QPS limit on the API.

```
$ curl -L -X PUT -H "Content-Type: application/json" -d '{"
region":"eu","realm_slug":"argent-dawn","character_slug":"funkitty"}' http://localhost:8080/api/user/194521955162914816/characters
{
  "active_spec": {
    "date_created": "2020-11-21 12:12",
    "date_modified": "2020-11-21 12:12",
    "id": 105,
    "name": "Restoration",
    "role": "HEALER"
  },
  "average_ilvl": 130,
  "date_created": "2020-11-21 12:12",
  "date_modified": "2020-11-21 12:12",
  "equipped_ilvl": 130,
  "faction": "ALLIANCE",
  "id": "redacted",
  "klass": {
    "date_created": "2020-11-21 12:12",
    "date_modified": "2020-11-21 12:12",
    "id": 11,
    "name": "Druid",
    "specs": [
      {
        "date_created": "2020-11-21 12:12",
        "date_modified": "2020-11-21 12:12",
        "id": 102,
        "name": "Balance",
        "role": "DAMAGE"
      },
      {
        "date_created": "2020-11-21 12:12",
        "date_modified": "2020-11-21 12:12",
        "id": 103,
        "name": "Feral",
        "role": "DAMAGE"
      },
      {
        "date_created": "2020-11-21 12:12",
        "date_modified": "2020-11-21 12:12",
        "id": 104,
        "name": "Guardian",
        "role": "TANK"
      },
      {
        "date_created": "2020-11-21 12:12",
        "date_modified": "2020-11-21 12:12",
        "id": 105,
        "name": "Restoration",
        "role": "HEALER"
      }
    ]
  },
  "name": "Funkitty",
  "realm": {
    "date_created": "2020-11-21 12:11",
    "date_modified": "2020-11-21 12:11",
    "id": 536,
    "name": "Argent Dawn",
    "region": "eu",
    "slug": "argent-dawn",
    "timezone_name": "Europe/Paris"
  }
}
```